### PR TITLE
Use railtie

### DIFF
--- a/lib/activerecord-after-transaction.rb
+++ b/lib/activerecord-after-transaction.rb
@@ -2,6 +2,10 @@ require 'active_record'
 require 'activerecord-after-transaction/version'
 require 'activerecord-after-transaction/methods'
 
-ActiveSupport.on_load :active_record do
-  include ActiveRecord::AfterTransaction::Methods
+if defined?(::Rails) 
+  require 'activerecord-after-transaction/railtie'
+else
+  ActiveSupport.on_load :active_record do
+    include ActiveRecord::AfterTransaction::Methods
+  end
 end

--- a/lib/activerecord-after-transaction/railtie.rb
+++ b/lib/activerecord-after-transaction/railtie.rb
@@ -1,0 +1,12 @@
+require 'active_record/railtie'
+require 'activerecord-after-transaction/methods'
+
+module ActiveRecordAfterTransaction
+  class Railtie < Rails::Railtie
+    initializer "active_record.include_after_transaction", after: "active_record.set_configs" do |app|
+      ActiveSupport.on_load :active_record do
+        include ActiveRecord::AfterTransaction::Methods
+      end
+    end
+  end
+end


### PR DESCRIPTION
Avoid the following error.

```
DEPRECATION WARNING: Currently, Active Record suppresses errors raised within `after_rollback`/`after_commit` callbacks and only print them to the logs. In the next version, these errors will no longer be suppressed. Instead, the errors will propagate normally just like in other Active Record callbacks.

You can opt into the new behavior and remove this warning by setting:

  config.active_record.raise_in_transactional_callbacks = true

 (called from require at /var/www/.rbenv/versions/2.1.4/lib/ruby/gems/2.1.0/gems/bundler-1.7.4/lib/bundler/runtime.rb:76)
```
